### PR TITLE
Adds query flags for part of speech

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     'no-console': 'off',
     'consistent-return': 'off',
     'max-len': ['warn', 120],
-    'comma-dangle': ['error', 'never']
+    'comma-dangle': ['error', 'never'],
+    'no-plusplus': 'off'
   },
 };

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ The Greek Goddess of wisdom takes on a new job as a definition-retrieving Discor
 
 - Define a word with `!define <word>`
   - Sends a message containing the word, part of speech, and definition.
+  - Define a word with a specific part of speech using query flags: `!define <flag> <word>` will return the noun definition of the word.
+  - Flags:
+    - `-n`: noun
+    - `-v`: verb
+    - `-adj`: adjective
+    - `-adv`: adverb
 - Play pronunciation of a word with `!pronounce <word>`
   - Joins the voice channel the user who sent this message is in and plays the word's pronunciation.
   - Alias: `!say <word>`


### PR DESCRIPTION
- Define a word with a specific part of speech using query flags: `!define <flag> <word>` will return the noun definition of the word.
- Flags:
  - `-n`: noun
  - `-v`: verb
  - `-adj`: adjective
  - `-adv`: adverb

Resolves #2.